### PR TITLE
TI-3169 - Manage life cycle for search functionality of generic imports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,6 @@
 {
 	"version": "0.2.0",
 	"configurations": [
-
 		{
 			"name": "Debug",
 			"type": "go",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.formatTool": "goimports"
+}

--- a/imqssearch.go
+++ b/imqssearch.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/IMQS/cli"
-	"github.com/IMQS/search/search"
 	"github.com/IMQS/gowinsvc/service"
+	"github.com/IMQS/search/search"
 	_ "github.com/lib/pq"
 )
 

--- a/search/benchmark.go
+++ b/search/benchmark.go
@@ -27,7 +27,7 @@ func BenchmarkReads(indexDB *sql.DB) {
 	defer tx.Commit()
 
 	start := time.Now()
-	var totalResults int64 = 0
+	var totalResults int64
 	numQuery := 5000
 	for i := 0; i < numQuery; i++ {
 		low := fmt.Sprintf("01%04v", i)

--- a/search/config.go
+++ b/search/config.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/IMQS/serviceconfigsgo"
+	serviceconfig "github.com/IMQS/serviceconfigsgo"
 	"github.com/pierrec/xxHash/xxHash32"
 )
 
@@ -106,7 +106,10 @@ and stdout is used for the Access log.
 }
 */
 
-const IndexDatabaseName = "index"
+const (
+	indexDatabaseName   = "index"
+	genericDatabaseName = "ImqsServerGeneric"
+)
 
 // Use load() and store() to read and write to an atomicTriState variable.
 type atomicTriState uint32
@@ -663,7 +666,7 @@ func (c *Config) generateConfigForHttpAPI() (string, error) {
 	cfg.Databases = map[string]*ConfigDatabase{}
 
 	for dbName, db := range c.Databases {
-		if dbName == IndexDatabaseName {
+		if dbName == indexDatabaseName {
 			continue
 		}
 		dbCopy := &ConfigDatabase{}

--- a/search/db.go
+++ b/search/db.go
@@ -2,18 +2,19 @@ package search
 
 import (
 	"database/sql"
+
 	//"fmt"
 	"strings"
 
 	"github.com/BurntSushi/migration"
+	"github.com/lib/pq"
 )
-
-var migrations []migration.Migrator
 
 // At some point we're going to need to make this configurable
 const ROWID = "rowid"
 
-func OpenIndexDB(cfg *ConfigDatabase) (*sql.DB, error) {
+func OpenIndexDB(cfg, genericCfg *ConfigDatabase) (*sql.DB, error) {
+	migrations := createMigrations(genericCfg)
 	db, err := migration.Open(cfg.Driver, cfg.DSN(), migrations)
 	if err == nil {
 		setDBConnectionLimits(cfg, db)
@@ -64,7 +65,12 @@ func escapeSqlLiteral(db *sql.DB, literal string) string {
 	return "'" + strings.Replace(literal, "'", "''", -1) + "'"
 }
 
-func init() {
+func createMigrations(genericCfg *ConfigDatabase) []migration.Migrator {
+	var migrations []migration.Migrator
+
+	// Each of these migrations corresponds to a version in whole migration.
+	// If a migration has more than one SQL statement, you must separate them with semicolons.
+
 	/*
 		--- Migration 1 ---
 		We have two options here:
@@ -86,22 +92,51 @@ func init() {
 		CREATE TABLE searchindex(token VARCHAR, srctab INTEGER, srcrow BIGINT);
 		CREATE INDEX idx_searchindex_token on searchindex(token);
 		CREATE INDEX idx_searchindex_srctab on searchindex(srctab);
+	*/
+	migrations = append(migrations, makeMigrationFromSQL(
+		`CREATE TABLE searchindex(token VARCHAR, srctab INTEGER, srcrow BIGINT, PRIMARY KEY(token, srctab, srcrow));
+		CREATE INDEX idx_searchindex_srctab ON searchindex(srctab);
+		CREATE TABLE searchtables(tablename VARCHAR, srctab INTEGER, PRIMARY KEY(tablename));
+		CREATE INDEX idx_searchtables_srctab ON searchtables(srctab);`))
 
+	/*
 		--- Migration 2 ---
 		Added modstamp
+	*/
+	migrations = append(migrations, makeMigrationFromSQL(
+		`DELETE FROM searchindex;
+		DELETE FROM searchtables;
+		ALTER TABLE searchtables ADD COLUMN modstamp VARCHAR;`))
 
+	/*
 		--- Migration 3 ---
 		Why COLLATION "C"? Without that, we can't generate ranges reliably. For example, '9' + 1 = ':',
 		but the default Postgres collation doesn't agree with that. By using the "C" collation, we get
 		to treat strings as simply binary byte strings.
+	*/
+	migrations = append(migrations, makeMigrationFromSQL(
+		`DELETE FROM searchtables;
+		DROP TABLE searchindex;
+		CREATE TABLE searchindex(token VARCHAR COLLATE "C", srctab INTEGER, srcrow BIGINT, PRIMARY KEY(token, srctab, srcrow));
+		CREATE INDEX idx_searchindex_srctab ON searchindex(srctab);`))
 
+	/*
 		--- Migration 4 ---
 		Automatic vacuums are taking down some old servers with HDDs. SSD servers are fine.
 		See 'doc.go' for more.
+	*/
+	migrations = append(migrations, makeMigrationFromSQL(
+		`ALTER TABLE searchindex SET (autovacuum_enabled = false);`))
 
+	/*
 		--- Migration 5 ---
 		Fixup: srctab must be unique
+	*/
+	migrations = append(migrations, makeMigrationFromSQL(
+		`DROP INDEX idx_searchtables_srctab;
+		CREATE UNIQUE INDEX idx_searchtables_srctab ON searchtables(srctab);`))
 
+	/*
 		--- Migration 6 ---
 		Upgrade the 'srctab' concept to the 'srcfield' concept. A 'srcfield'
 		is (srctab << 16 | srcfield). It allows us to limit our search results by field.
@@ -109,42 +144,8 @@ func init() {
 		string to small integer. We use this for both table names and field names, so that
 		we can form a unique integer for every field (ie srctab << 16 | srcfield mentioned above).
 		Change naming convention to use underscores.
-
-		--- Migration 7 ---
-		Change (srcrow BIGINT) to (srcrows BYTEA), so that we can represent relationships tables.
-
-		--- Migration 8 ---
-		Create new table that will store additional config settings to the file-based config.
 	*/
-
-	// Each string in this array is one migration.
-	// If a migration has more than one SQL statement, then separate them with semicolons.
-	text := []string{
-		// 1
-		`CREATE TABLE searchindex(token VARCHAR, srctab INTEGER, srcrow BIGINT, PRIMARY KEY(token, srctab, srcrow));
-		CREATE INDEX idx_searchindex_srctab ON searchindex(srctab);
-		CREATE TABLE searchtables(tablename VARCHAR, srctab INTEGER, PRIMARY KEY(tablename));
-		CREATE INDEX idx_searchtables_srctab ON searchtables(srctab);`,
-
-		// 2
-		`DELETE FROM searchindex;
-		DELETE FROM searchtables;
-		ALTER TABLE searchtables ADD COLUMN modstamp VARCHAR;`,
-
-		// 3
-		`DELETE FROM searchtables;
-		DROP TABLE searchindex;
-		CREATE TABLE searchindex(token VARCHAR COLLATE "C", srctab INTEGER, srcrow BIGINT, PRIMARY KEY(token, srctab, srcrow));
-		CREATE INDEX idx_searchindex_srctab ON searchindex(srctab);`,
-
-		// 4
-		`ALTER TABLE searchindex SET (autovacuum_enabled = false)`,
-
-		// 5
-		`DROP INDEX idx_searchtables_srctab;
-		CREATE UNIQUE INDEX idx_searchtables_srctab ON searchtables(srctab);`,
-
-		// 6
+	migrations = append(migrations, makeMigrationFromSQL(
 		`DROP TABLE searchindex;
 		DROP TABLE searchtables;
 		CREATE TABLE search_index(token VARCHAR COLLATE "C", srcfield INTEGER, srcrow BIGINT, PRIMARY KEY(token, srcfield, srcrow));
@@ -152,23 +153,91 @@ func init() {
 		ALTER TABLE search_index SET (autovacuum_enabled = false);
 		CREATE TABLE search_nametable(name VARCHAR, id INTEGER, PRIMARY KEY(name));
 		CREATE UNIQUE INDEX idx_search_nametable_id ON search_nametable(id);
-		CREATE TABLE search_src_tables(tablename VARCHAR, modstamp VARCHAR, PRIMARY KEY(tablename));`,
+		CREATE TABLE search_src_tables(tablename VARCHAR, modstamp VARCHAR, PRIMARY KEY(tablename));`))
 
-		// 7
+	/*
+		--- Migration 7 ---
+		Change (srcrow BIGINT) to (srcrows BYTEA), so that we can represent relationships tables.
+	*/
+	migrations = append(migrations, makeMigrationFromSQL(
 		`DROP TABLE search_index;
 		CREATE TABLE search_index(token VARCHAR COLLATE "C", srcfield INTEGER, srcrows BYTEA, PRIMARY KEY(token, srcfield, srcrows));
 		CREATE INDEX idx_search_index_srcfield ON search_index(srcfield);
-		ALTER TABLE search_index SET (autovacuum_enabled = false);`,
+		ALTER TABLE search_index SET (autovacuum_enabled = false);`))
 
-		// 8
-		`CREATE TABLE search_config (dbname VARCHAR, tablename VARCHAR, config JSONB, PRIMARY KEY (dbname, tablename));`, //We can now store configuration settings inside the database (in addition to the JSON config file)
-	}
+	/*
+		--- Migration 8 ---
+		Create new table that will store additional config settings to the file-based config.
+		We can now store configuration settings inside the database (in addition to the JSON config file)
+	*/
+	migrations = append(migrations, makeMigrationFromSQL(
+		`CREATE TABLE search_config (dbname VARCHAR, tablename VARCHAR, config JSONB, PRIMARY KEY (dbname, tablename));`))
 
-	for _, src := range text {
-		srcCapture := src
-		migrations = append(migrations, func(tx migration.LimitedTx) error {
-			_, err := tx.Exec(srcCapture)
+	/*
+		--- Migration 9 ---
+		In the generic system, every time there is a new import,
+		a new table name is reserved for each of the files contained in the import.
+		That name which will look like, for example g_table_2, where the last digit is incremented for each new table,
+		will change with each import of the same file. So to keep track of all these changes we created another
+		field called the tablename_external in the IMQS_METATABLE on the generic database which keeps tracks of the import file name.
+
+		The issue then becomes what should happen to the already indexed fields for that generic table which are being
+		stored in the search_config table, when the generic file is reimported or deleted from the original database?
+		Thats why we have added a new field to the search_config table called the long_lived_name. Just like
+		the table_external_name in the IMQS MetaTable table, this field will store the original name of the table
+		and we expect it to never change between diffent re-imports.
+
+		We can update or delete any search_config using long_lived_name field as a reference
+	*/
+	migrations = append(migrations, func(tx migration.LimitedTx) error {
+		tableNames := make([]string, 0)
+		nameRows, err := tx.Query(`SELECT tablename FROM search_config`)
+		if err != nil {
 			return err
-		})
+		}
+		defer nameRows.Close()
+		for nameRows.Next() {
+			var name string
+			if err := nameRows.Scan(&name); err != nil {
+				return err
+			}
+			tableNames = append(tableNames, name)
+		}
+
+		migrationSQL := `ALTER TABLE search_config DROP CONSTRAINT search_config_pkey; ALTER TABLE search_config ADD COLUMN longlived_name VARCHAR;`
+		if len(tableNames) > 0 {
+			genericDB, err := sql.Open(genericCfg.Driver, genericCfg.DSN())
+			if err != nil {
+				return err
+			}
+			defer genericDB.Close()
+
+			metaRows, err := genericDB.Query(`SELECT "TableNameInternal", "TableNameExternal" FROM "ImqsMetaTable" WHERE "TableNameInternal" = any($1)`, pq.Array(tableNames))
+			if err != nil {
+				return err
+			}
+			defer metaRows.Close()
+
+			for metaRows.Next() {
+				var internalName, externalName string
+				if err := metaRows.Scan(&internalName, &externalName); err != nil {
+					return err
+				}
+				migrationSQL += `UPDATE search_config SET longlived_name = '` + externalName + `' WHERE tablename = '` + internalName + `'; `
+			}
+		}
+		migrationSQL += `ALTER TABLE search_config ADD CONSTRAINT search_config_pkey PRIMARY KEY (dbname, longlived_name);`
+
+		_, err = tx.Exec(migrationSQL)
+		return err
+	})
+
+	return migrations
+}
+
+func makeMigrationFromSQL(sql string) migration.Migrator {
+	return func(tx migration.LimitedTx) error {
+		_, err := tx.Exec(sql)
+		return err
 	}
 }

--- a/search/engine-test-search.json
+++ b/search/engine-test-search.json
@@ -1,25 +1,32 @@
 {
 	"Databases": {
 		"index": {
-			"Driver":		"postgres",
-			"Host":			"127.0.0.1",
-			"Database": 	"unit_test_search_index",
-			"User":			"unit_test_user",
-			"Password":		"unit_test_password"
+			"Driver": "postgres",
+			"Host": "127.0.0.1",
+			"Database": "unit_test_search_index",
+			"User": "unit_test_user",
+			"Password": "unit_test_password"
+		},
+		"ImqsServerGeneric": {
+			"Driver": "postgres",
+			"Host": "127.0.0.1",
+			"Database": "unit_test_generic",
+			"User": "unit_test_user",
+			"Password": "unit_test_password"
 		},
 		"db1": {
-			"Driver":		"postgres",
-			"Host":			"127.0.0.1",
-			"Database": 	"unit_test_search_src1",
-			"User":			"unit_test_user",
-			"Password":		"unit_test_password"
+			"Driver": "postgres",
+			"Host": "127.0.0.1",
+			"Database": "unit_test_search_src1",
+			"User": "unit_test_user",
+			"Password": "unit_test_password"
 		},
 		"db2": {
-			"Driver":		"postgres",
-			"Host":			"127.0.0.1",
-			"Database": 	"unit_test_search_src2",
-			"User":			"unit_test_user",
-			"Password":		"unit_test_password"
+			"Driver": "postgres",
+			"Host": "127.0.0.1",
+			"Database": "unit_test_search_src2",
+			"User": "unit_test_user",
+			"Password": "unit_test_password"
 		}
 	}
 }


### PR DESCRIPTION
Please review

Changes:
1) Add delete config for table API
2) Add rename table API
3) Add ability to save generic table names (External Names)