### PR TITLE
fix(migration): Single quotes not escaped

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# docker build -t imqs/search:master --build-arg SSH_KEY="`cat ~/.ssh/id_rsa`" .
+# docker build -t imqs/search:latest --build-arg SSH_KEY="`cat ~/.ssh/id_rsa`" .
 
 ##################################
 # Builder image

--- a/server/db.go
+++ b/server/db.go
@@ -224,10 +224,7 @@ func createMigrations(genericCfg *serviceconfig.DBConfig) []migration.Migrator {
 					return err
 				}
 
-				// Escape single quotes in names
-				externalName = strings.Replace(externalName, `'`, `''`, -1)
-
-				migrationSQL += `UPDATE search_config SET longlived_name = '` + externalName + `' WHERE tablename = '` + internalName + `'; `
+				migrationSQL += `UPDATE search_config SET longlived_name = ` + escapeSQLLiteral(genericDB, externalName) + ` WHERE tablename = '` + internalName + `'; `
 			}
 			metaRows.Close()
 

--- a/server/db.go
+++ b/server/db.go
@@ -223,6 +223,10 @@ func createMigrations(genericCfg *serviceconfig.DBConfig) []migration.Migrator {
 				if err := metaRows.Scan(&internalName, &externalName); err != nil {
 					return err
 				}
+
+				// Escape single quotes in names
+				externalName = strings.Replace(externalName, `'`, `''`, -1)
+
 				migrationSQL += `UPDATE search_config SET longlived_name = '` + externalName + `' WHERE tablename = '` + internalName + `'; `
 			}
 			metaRows.Close()


### PR DESCRIPTION
Changes migration 9 to escape the `externalName` for single quotes

Refs: ASG-5083